### PR TITLE
Tempfile Fixes

### DIFF
--- a/src/pipeline_replacer.rs
+++ b/src/pipeline_replacer.rs
@@ -125,7 +125,7 @@ impl SimplePipelineReplacer {
             let metadata = try!( fs::metadata( &pm.path ) );
 
             try!( fs::set_permissions( tmpfile.path(), metadata.permissions() ) );
-            try!( fs::rename( tmpfile.path(), &pm.path ) );
+            try!( tmpfile.persist( &pm.path ) );
 
             Ok(())
         } );

--- a/src/pipeline_replacer.rs
+++ b/src/pipeline_replacer.rs
@@ -1,7 +1,6 @@
 use console::{Console, ConsoleTextKind};
 use memmap::{Mmap, Protection};
 use pipeline_matcher::PathMatch;
-use std::env;
 use std::fs;
 use std::io;
 use std::io::{Write, Error};
@@ -59,8 +58,7 @@ impl SimplePipelineReplacer {
         self.console.is_color = self.is_color;
 
         let result = catch::<_, (), Error> ( || {
-            let tmpfile_dir = env::temp_dir();
-            let mut tmpfile = try!( NamedTempFile::new_in( tmpfile_dir ) );
+            let mut tmpfile = try!( NamedTempFile::new_in( pm.path.parent().unwrap_or( &pm.path ) )  );
 
             {
                 let mmap = try!( Mmap::open_path( &pm.path, Protection::Read ) );

--- a/src/pipeline_replacer.rs
+++ b/src/pipeline_replacer.rs
@@ -124,8 +124,8 @@ impl SimplePipelineReplacer {
 
             let metadata = try!( fs::metadata( &pm.path ) );
 
+            try!( fs::set_permissions( tmpfile.path(), metadata.permissions() ) );
             try!( fs::rename( tmpfile.path(), &pm.path ) );
-            try!( fs::set_permissions( &pm.path, metadata.permissions() ) );
 
             Ok(())
         } );


### PR DESCRIPTION
1. It's a good idea to use NamedTempFile::persist instead of rename.

2. Changing the permissions *before* renaming ensures that the permissions are always correct.

3. Files can't be renamed across filesystems so the only bug-free way to do this is to put the temporary file in the same directory as the target file. This does mean that if the `NamedTempFile` destructor doesn't run, the temporary file will be left in a non-temporary directory but there isn't really any way to work around this (that I know of).