### PR TITLE
Create a dummy .git/config file if it doesn't exist

### DIFF
--- a/src/pipeline_finder.rs
+++ b/src/pipeline_finder.rs
@@ -276,7 +276,7 @@ mod tests {
     use super::*;
     use crate::pipeline::{PipelineFork, PipelineInfo};
     use crossbeam_channel::unbounded;
-    use std::path::PathBuf;
+    use std::path::{Path,PathBuf};
     use std::thread;
 
     fn test<T: 'static + PipelineFork<PathBuf, PathInfo> + Send>(mut finder: T, path: String) -> Vec<PathInfo> {
@@ -303,6 +303,11 @@ mod tests {
 
     #[test]
     fn pipeline_finder_default() {
+        if !Path::new("./.git/config").exists() {
+            fs::create_dir_all("./.git").unwrap();
+            fs::File::create("./.git/config").unwrap();
+        }
+
         let finder = PipelineFinder::new();
         let ret = test(finder, "./".to_string());
 
@@ -318,6 +323,11 @@ mod tests {
 
     #[test]
     fn pipeline_finder_not_skip_vcs() {
+        if !Path::new("./.git/config").exists() {
+            fs::create_dir_all("./.git").unwrap();
+            fs::File::create("./.git/config").unwrap();
+        }
+
         let mut finder = PipelineFinder::new();
         finder.skip_vcs = false;
         let ret = test(finder, "./".to_string());


### PR DESCRIPTION
Right now, if you download a tarball of the project and then build it,
"cargo test" fails because GitHub tarballs don't include the .git
directory. This breaks the pipeline_finder tests, which ensure that the
.git/config file is or is not found.

My solution was to create an empty .git/config file if no such file
exists already. This is sufficient to make the tests pass even though
there isn't a "real" .git directory.

One downside of this approach is that a dummy .git/config file is left
over after the tests are run. I imagine that this won't be a problem,
since it will mostly be automated build tools that download the
tarball--developers will clone the repository and users will download
the binaries. My first pass at this did clean up the file at the end of
each test but, since the tests are run in parallel, one of them would
delete the file while the other was still using it. I suppose it would
also be possible to reintroduce the cleanup code and just force the
tests to run serially, if you'd like that approach better.