### PR TITLE
fix: --max-threads

### DIFF
--- a/src/ambr.rs
+++ b/src/ambr.rs
@@ -49,7 +49,7 @@ pub struct Opt {
     pub paths: Vec<String>,
 
     /// Number of max threads
-    #[structopt(long = "max-threads", default_value = "&MAX_THREADS", value_name = "NUM")]
+    #[structopt(long = "max-threads", default_value = &MAX_THREADS, value_name = "NUM")]
     pub max_threads: usize,
 
     /// File size per one thread

--- a/src/ambs.rs
+++ b/src/ambs.rs
@@ -41,7 +41,7 @@ pub struct Opt {
     pub paths: Vec<String>,
 
     /// Number of max threads
-    #[structopt(long = "max-threads", default_value = "&MAX_THREADS", value_name = "NUM")]
+    #[structopt(long = "max-threads", default_value = &MAX_THREADS, value_name = "NUM")]
     pub max_threads: usize,
 
     /// File size per one thread


### PR DESCRIPTION
Fixes the following issue:
```sh
» ambs t
error: Invalid value for '--max-threads <NUM>': invalid digit found in string
```