### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -217,28 +217,28 @@ impl IgnoreGit {
         let path_end = (path_str.len() - 1) as isize;
 
         for p in names {
-            unsafe {
-                if (p.head != 0) && (*name_ptr != p.head) {
+            
+                if (p.head != 0) && (unsafe { *name_ptr } != p.head) {
                     continue;
                 }
-                if (p.tail != 0) && (*name_ptr.offset(name_end) != p.tail) {
+                if (p.tail != 0) && (unsafe { *name_ptr.offset(name_end) } != p.tail) {
                     continue;
                 }
-            }
+            
             if p.pat.matches_with(&name_str, self.opt) {
                 return true;
             }
         }
 
         for p in paths {
-            unsafe {
-                if (p.head != 0) && (*path_ptr != p.head) {
+            
+                if (p.head != 0) && (unsafe { *path_ptr } != p.head) {
                     continue;
                 }
-                if (p.tail != 0) && (*path_ptr.offset(path_end) != p.tail) {
+                if (p.tail != 0) && (unsafe { *path_ptr.offset(path_end) } != p.tail) {
                     continue;
                 }
-            }
+            
             if p.pat.matches_with(&path_str, self.opt) {
                 return true;
             }


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions. However, I found that only 2 operations are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. dereference raw pointer(*name_ptr)
2. the offset() function(unsafe function)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 