### PR TITLE
Replace yaourt with yay in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can decide to do replacing or not interactively.
 Install the `amber-search-git` package from AUR.
 
 ```
-yaourt -S amber-search-git
+yay -S amber-search-git
 ```
 
 ### Cargo


### PR DESCRIPTION
Yaourt has been unmaintained since ~2019 and is superseded by yay. https://github.com/archlinuxfr/yaourt